### PR TITLE
Changed target framework to .NET 4 Client Profile

### DIFF
--- a/src/ServiceWire/ServiceWire.csproj
+++ b/src/ServiceWire/ServiceWire.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>ServiceWire</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Tests/Integration/ServiceWireTestClient1/App.config
+++ b/src/Tests/Integration/ServiceWireTestClient1/App.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0"?>
 <configuration>
     <appSettings>
-        <add key="ip" value="127.0.0.1" />
-        <add key="port" value="8098" />
+        <add key="ip" value="127.0.0.1"/>
+        <add key="port" value="8098"/>
     </appSettings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0,Profile=Client"/></startup></configuration>

--- a/src/Tests/Integration/ServiceWireTestClient1/ServiceWireTestClient1.csproj
+++ b/src/Tests/Integration/ServiceWireTestClient1/ServiceWireTestClient1.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>ServiceWireTestClient1</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Tests/Integration/ServiceWireTestClient2/App.config
+++ b/src/Tests/Integration/ServiceWireTestClient2/App.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0"?>
 <configuration>
     <appSettings>
-        <add key="ip" value="127.0.0.1" />
-        <add key="port" value="8098" />
+        <add key="ip" value="127.0.0.1"/>
+        <add key="port" value="8098"/>
     </appSettings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0,Profile=Client"/></startup></configuration>

--- a/src/Tests/Integration/ServiceWireTestClient2/ServiceWireTestClient2.csproj
+++ b/src/Tests/Integration/ServiceWireTestClient2/ServiceWireTestClient2.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>ServiceWireTestClient2</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Tests/Integration/ServiceWireTestHost/App.config
+++ b/src/Tests/Integration/ServiceWireTestHost/App.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0"?>
 <configuration>
     <appSettings>
-        <add key="ip" value="127.0.0.1" />
-        <add key="port" value="8098" />
+        <add key="ip" value="127.0.0.1"/>
+        <add key="port" value="8098"/>
     </appSettings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0,Profile=Client"/></startup></configuration>

--- a/src/Tests/Integration/ServiceWireTestHost/ServiceWireTestHost.csproj
+++ b/src/Tests/Integration/ServiceWireTestHost/ServiceWireTestHost.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>ServiceWireTestHost</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Tests/ServiceWireTestCommon/ServiceWireTestCommon.csproj
+++ b/src/Tests/ServiceWireTestCommon/ServiceWireTestCommon.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>ServiceWireTestCommon</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Tests/Unit/ServiceWireTests/ServiceWireTests.csproj
+++ b/src/Tests/Unit/ServiceWireTests/ServiceWireTests.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
ServiceWire does not use any of the additional features of .NET
Framework's Full profile, so it just makes sense to have it target the
Client Profile.