### PR TITLE
Update ProxyFactory.cs

### DIFF
--- a/src/ServiceWire/ProxyFactory.cs
+++ b/src/ServiceWire/ProxyFactory.cs
@@ -187,12 +187,12 @@ namespace ServiceWire
             //declare and assign string literal
             LocalBuilder metaLB = mIL.DeclareLocal(typeof(string));
             metaLB.SetLocalSymInfo("metaData", 1, 2);
-            mIL.Emit(OpCodes.Dup);
+            //mIL.Emit(OpCodes.Dup);  //causes InvalidProgramException - Common Language Runtime detected an invalid program.
             mIL.Emit(OpCodes.Ldstr, metadata);
             mIL.Emit(OpCodes.Stloc_1); //load into metaData local variable
 
             //load metadata into first param for invokeMethodMI
-            mIL.Emit(OpCodes.Dup);
+            //mIL.Emit(OpCodes.Dup);  //causes InvalidProgramException - Common Language Runtime detected an invalid program.
             mIL.Emit(OpCodes.Ldloc_1);
 
             mIL.Emit(OpCodes.Ldc_I4, nofArgs); //push the number of arguments


### PR DESCRIPTION
While integrating ServiceWire with my VS2015 project, I received an InvalidProgramException - "Common Language Runtime detected an invalid program.".  I modified ProxyFactory.cs to save ProxyAssembly.dll, then analyzed it with peverify.exe, which returned the following error message, "Stack must be empty on return from a void function."  After walking the ProxyAssembly.dll IL by hand, and some tinkering, I was able to generate a ProxyAssembly.dll assembly that did not throw an InvalidProgramException.  The only changes I made were to comment out 2 lines in ProxyFactory.cs, 190, and 195.