### PR TITLE
Added support to use Task and Task<>

### DIFF
--- a/src/Demo/DemoClient/Program.cs
+++ b/src/Demo/DemoClient/Program.cs
@@ -39,28 +39,35 @@ namespace DemoClient
             Console.ReadLine();
         }
 
-        private static void RunTest(TcpZkEndPoint zkEndpoint, string ip, Logger logger, Stats stats)
+        private static async Task RunTest(TcpZkEndPoint zkEndpoint, string ip, Logger logger, Stats stats)
         {
             var sw = Stopwatch.StartNew();
-            using (var client = new TcpClient<IDataContract>(zkEndpoint))
-            {
-                client.InjectLoggerStats(logger, stats);
+			using (var client = new TcpClient<ITest>(zkEndpoint))
+			{
+				client.InjectLoggerStats(logger, stats);
+				await client.Proxy.SetAsync(1);
+				int value = await client.Proxy.GetAsync();
+			}
 
-                decimal abc = client.Proxy.GetDecimal(4.5m);
-                bool result = client.Proxy.OutDecimal(abc);
-            }
+			using (var client = new TcpClient<IDataContract>(zkEndpoint))
+			{
+				client.InjectLoggerStats(logger, stats);
 
-            using (var client = new TcpClient<IComplexDataContract>(zkEndpoint))
-            {
-                client.InjectLoggerStats(logger, stats);
+				decimal abc = client.Proxy.GetDecimal(4.5m);
+				bool result = client.Proxy.OutDecimal(abc);
+			}
 
-                var id = client.Proxy.GetId("test1", 3.314, 42, DateTime.Now);
-                long q = 3;
-                var response = client.Proxy.Get(id, "mirror", 4.123, out q);
-                var list = client.Proxy.GetItems(id);
-            }
+			using (var client = new TcpClient<IComplexDataContract>(zkEndpoint))
+			{
+				client.InjectLoggerStats(logger, stats);
 
-            Console.WriteLine("elapsed ms: {0}", sw.ElapsedMilliseconds);
+				var id = client.Proxy.GetId("test1", 3.314, 42, DateTime.Now);
+				long q = 3;
+				var response = client.Proxy.Get(id, "mirror", 4.123, out q);
+				var list = client.Proxy.GetItems(id);
+			}
+
+			Console.WriteLine("elapsed ms: {0}", sw.ElapsedMilliseconds);
         }
     }
 }

--- a/src/Demo/DemoCommon/Contracts.cs
+++ b/src/Demo/DemoCommon/Contracts.cs
@@ -1,11 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace DemoCommon
 {
+	public interface ITest
+	{
+		Task SetAsync(int a);
+		Task<int> GetAsync();
+	}
+
     public interface IDataContract
     {
         decimal GetDecimal(decimal input);

--- a/src/Demo/DemoHost/Program.cs
+++ b/src/Demo/DemoHost/Program.cs
@@ -17,7 +17,7 @@ namespace DemoHost
         {
             var logger = new Logger(logLevel: LogLevel.Debug);
             var stats = new Stats();
-
+			 
             var addr = new[] { "127.0.0.1", "8098" }; //defaults
             if (null != args && args.Length > 0)
             {
@@ -38,11 +38,14 @@ namespace DemoHost
             tcphost.UseCompression = useCompression;
             tcphost.CompressionThreshold = compressionThreshold;
 
-            var simpleContract = new DataContractImpl();
-            tcphost.AddService<IDataContract>(simpleContract);
+			var simpleContract = new DataContractImpl();
+			tcphost.AddService<IDataContract>(simpleContract);
 
-            var complexContract = new ComplexDataContractImpl();
-            tcphost.AddService<IComplexDataContract>(complexContract);
+			var complexContract = new ComplexDataContractImpl();
+			tcphost.AddService<IComplexDataContract>(complexContract);
+
+			var test = new Test();
+			tcphost.AddService<ITest>(test);
 
             tcphost.Open();
 
@@ -54,6 +57,19 @@ namespace DemoHost
             Console.WriteLine("Press Enter to quit.");
             Console.ReadLine();
         }
+    }
+
+    public class Test : ITest
+    {
+	    public Task SetAsync(int a)
+	    {
+			return Task.CompletedTask;
+		}
+
+	    public Task<int> GetAsync()
+	    {
+			return Task.FromResult(1);
+		}
     }
 
     public class DataContractImpl : IDataContract

--- a/src/ServiceWire/MethodSyncInfo.cs
+++ b/src/ServiceWire/MethodSyncInfo.cs
@@ -6,6 +6,7 @@ namespace ServiceWire
     {
         public int MethodIdent { get; set; }
         public string MethodName { get; set; }
-        public Type[] ParameterTypes { get; set; }
+        public Type MethodReturnType { get; set; }
+		public Type[] ParameterTypes { get; set; }
     }
 }

--- a/src/ServiceWire/TcpIp/TcpClient.cs
+++ b/src/ServiceWire/TcpIp/TcpClient.cs
@@ -5,45 +5,34 @@ namespace ServiceWire.TcpIp
 {
     public class TcpClient<TInterface> : IDisposable where TInterface : class
     {
-        private TInterface _proxy;
+		public TInterface Proxy { get; }
 
-        public TInterface Proxy { get { return _proxy; } }
-
-        public TcpClient(TcpEndPoint endpoint)
+		public TcpClient(TcpEndPoint endpoint)
         {
-            _proxy = TcpProxy.CreateProxy<TInterface>(endpoint);
+            Proxy = TcpProxy.CreateProxy<TInterface>(endpoint);
         }
 
         public TcpClient(TcpZkEndPoint endpoint)
         {
-            _proxy = TcpProxy.CreateProxy<TInterface>(endpoint);
+            Proxy = TcpProxy.CreateProxy<TInterface>(endpoint);
         }
 
         public TcpClient(IPEndPoint endpoint)
         {
-            _proxy = TcpProxy.CreateProxy<TInterface>(endpoint);
+            Proxy = TcpProxy.CreateProxy<TInterface>(endpoint);
         }
 
         public void InjectLoggerStats(ILog logger, IStats stats)
         {
-            if (_proxy != null)
-            {
-                var channel = _proxy as Channel;
-                if (channel != null) channel.InjectLoggerStats(logger, stats);
-            };
+	        var channel = Proxy as Channel;
+	        channel?.InjectLoggerStats(logger, stats);
         }
 
-        public bool IsConnected
-        {
-            get
-            {
-                return (_proxy != null) && (_proxy as TcpChannel).IsConnected;
-            }
-        }
+        public bool IsConnected => (Proxy as TcpChannel)?.IsConnected == true;
 
         #region IDisposable Members
 
-        private bool _disposed = false;
+        private bool _disposed;
 
         public void Dispose()
         {
@@ -59,7 +48,7 @@ namespace ServiceWire.TcpIp
                 _disposed = true; //prevent second call to Dispose
                 if (disposing)
                 {
-                    (_proxy as TcpChannel).Dispose();
+                    (Proxy as TcpChannel)?.Dispose();
                 }
             }
         }

--- a/src/Tests/Integration/ServiceWireTestClient1/Program.cs
+++ b/src/Tests/Integration/ServiceWireTestClient1/Program.cs
@@ -43,6 +43,7 @@ namespace ServiceWireTestClient1
                 long q = 3;
                 var response = client.Get(id, "mirror", 4.123, out q);
                 var list = client.GetItems(id);
+                var listFromAsync = client.GetItemsAsync(id).GetAwaiter().GetResult();
             }
             using (var client = new NetTcpMyTesterProxy(ipEndpoint))
             {
@@ -65,7 +66,8 @@ namespace ServiceWireTestClient1
                         long q = 2;
                         var response = client.Get(id, "mirror", 4.123, out q);
                         var list = client.GetItems(id);
-                    }
+                        var listFromAsync = client.GetItemsAsync(id).GetAwaiter().GetResult();
+					}
                 }
 
                 using (var client = new NetTcpMyTesterProxy(ipEndpoint))
@@ -92,7 +94,8 @@ namespace ServiceWireTestClient1
                     long q = 2;
                     var response = client.Get(id, "mirror", 4.123, out q);
                     var list = client.GetItems(id);
-                }
+                    var listFromAsync = client.GetItemsAsync(id).GetAwaiter().GetResult();
+				}
 
                 sw = Stopwatch.StartNew();
                 Parallel.For(from, to, index =>
@@ -105,8 +108,9 @@ namespace ServiceWireTestClient1
                             long q = 4;
                             var response = client.Get(id, "mirror", 4.123, out q);
                             var list = client.GetItems(id);
+                            var listFromAsync = client.GetItemsAsync(id).GetAwaiter().GetResult();
 
-                            long id1;
+							long id1;
                             long id2;
                             long id3 = client.TestLong(out id1, out id2);
                         }

--- a/src/Tests/Integration/ServiceWireTestClient2/Program.cs
+++ b/src/Tests/Integration/ServiceWireTestClient2/Program.cs
@@ -22,7 +22,7 @@ namespace ServiceWireTestClient2
             Console.ReadLine();
         }
 
-        private static void RunTest(IPEndPoint ipEndpoint, string ip)
+        private static async Task RunTest(IPEndPoint ipEndpoint, string ip)
         {
             using (var client = new TcpClient<IValTypes>(ipEndpoint))
             {
@@ -30,12 +30,19 @@ namespace ServiceWireTestClient2
                 bool result = client.Proxy.OutDecimal(abc);
             }
 
-            using (var client = new NetTcpTesterProxy(ipEndpoint))
+            using (var client = new TcpClient<IValTypes>(ipEndpoint))
+            {
+	            decimal abc = await client.Proxy.GetDecimalAsync(4.5m);
+	            bool result = await client.Proxy.OutDecimalAsync(abc);
+            }
+
+			using (var client = new NetTcpTesterProxy(ipEndpoint))
             {
                 var id = client.GetId("test1", 3.314, 42, DateTime.Now);
                 long q = 3;
                 var response = client.Get(id, "mirror", 4.123, out q);
                 var list = client.GetItems(id);
+                var listFromAsync = await client.GetItemsAsync(id);
             }
             using (var client = new NetTcpMyTesterProxy(ipEndpoint))
             {

--- a/src/Tests/Integration/ServiceWireTestHost/Program.cs
+++ b/src/Tests/Integration/ServiceWireTestHost/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Net;
 using System.Text;
+using System.Threading.Tasks;
 using ServiceWire;
 using ServiceWire.NamedPipes;
 using ServiceWire.TcpIp;
@@ -63,10 +64,20 @@ namespace ServiceWireTestHost
             return input += 456.44m;
         }
 
+        public Task<decimal> GetDecimalAsync(decimal input)
+        {
+			return Task.FromResult(GetDecimal(input));
+		}
+
         public bool OutDecimal(decimal val)
         {
             val = 45.66m;
             return true;
+        }
+
+        public Task<bool> OutDecimalAsync(decimal val)
+        {
+	        return Task.FromResult(OutDecimal(val));
         }
     }
 
@@ -92,7 +103,12 @@ namespace ServiceWireTestHost
 			return list;
 		}
 
-        public long TestLong(out long id1, out long id2)
+		public Task<List<string>> GetItemsAsync(Guid id)
+		{
+			return Task.FromResult(GetItems(id));
+		}
+
+		public long TestLong(out long id1, out long id2)
         {
             id1 = 23;
             id2 = 24;

--- a/src/Tests/ServiceWireTestCommon/TestContracts.cs
+++ b/src/Tests/ServiceWireTestCommon/TestContracts.cs
@@ -2,16 +2,17 @@
 using ServiceWire.TcpIp;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
+using System.Threading.Tasks;
 
 namespace ServiceWireTestCommon
 {
     public interface IValTypes
     {
         decimal GetDecimal(decimal input);
+        Task<decimal> GetDecimalAsync(decimal input);
         bool OutDecimal(decimal val);
+        Task<bool> OutDecimalAsync(decimal val);
     }
     
     public interface INetTester
@@ -20,6 +21,7 @@ namespace ServiceWireTestCommon
         TestResponse Get(Guid id, string label, double weight, out long quantity);
         long TestLong(out long id1, out long id2);
         List<string> GetItems(Guid id);
+        Task<List<string>> GetItemsAsync(Guid id);
     }
 
     public interface IMyTester
@@ -61,6 +63,11 @@ namespace ServiceWireTestCommon
             return Proxy.GetItems(id);
         }
 
+        public Task<List<string>> GetItemsAsync(Guid id)
+        {
+	        return Task.FromResult(Proxy.GetItems(id));
+        }
+
         public long TestLong(out long id1, out long id2)
         {
             id1 = 23;
@@ -88,6 +95,11 @@ namespace ServiceWireTestCommon
         public List<string> GetItems(Guid id)
         {
             return Proxy.GetItems(id);
+        }
+
+        public Task<List<string>> GetItemsAsync(Guid id)
+        {
+	        return Task.FromResult(Proxy.GetItems(id));
         }
 
         public long TestLong(out long id1, out long id2)

--- a/src/Tests/Unit/ServiceWireTests/INetTester.cs
+++ b/src/Tests/Unit/ServiceWireTests/INetTester.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace ServiceWireTests
 {
@@ -8,6 +9,8 @@ namespace ServiceWireTests
     {
         int Min(int a, int b);
         Dictionary<int, int> Range(int start, int count);
+        Task<int> CalculateAsync(int a, int b);
+
     }
 
     public class NetTester : INetTester
@@ -20,6 +23,11 @@ namespace ServiceWireTests
         public Dictionary<int, int> Range(int start, int count)
         {
             return Enumerable.Range(start, count).ToDictionary(key => key, el => el);
+        }
+
+        public Task<int> CalculateAsync(int a, int b)
+        {
+	        return Task.FromResult(a + b);
         }
     }
 }

--- a/src/Tests/Unit/ServiceWireTests/NpTests.cs
+++ b/src/Tests/Unit/ServiceWireTests/NpTests.cs
@@ -43,6 +43,21 @@ namespace ServiceWireTests
         }
 
         [Fact]
+        public async Task CalculateAsyncTest()
+        {
+	        var rnd = new Random();
+
+	        var a = rnd.Next(0, 100);
+	        var b = rnd.Next(0, 100);
+
+	        using (var clientProxy = new NpClient<INetTester>(CreateEndPoint()))
+	        {
+		        var result = await clientProxy.Proxy.CalculateAsync(a, b);
+		        Assert.Equal(a + b, result);
+	        }
+        }
+
+		[Fact]
         public void SimpleParallelTest()
         {
             var rnd = new Random();

--- a/src/Tests/Unit/ServiceWireTests/TcpTests.cs
+++ b/src/Tests/Unit/ServiceWireTests/TcpTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using ServiceWire.TcpIp;
@@ -46,6 +45,21 @@ namespace ServiceWireTests
         }
 
         [Fact]
+        public async Task CalculateAsyncTest()
+        {
+	        var rnd = new Random();
+
+	        var a = rnd.Next(0, 100);
+	        var b = rnd.Next(0, 100);
+
+	        using (var clientProxy = new TcpClient<INetTester>(CreateEndPoint()))
+	        {
+		        var result = await clientProxy.Proxy.CalculateAsync(a, b);
+		        Assert.Equal(a + b, result);
+	        }
+        }
+
+		[Fact]
         public void SimpleParallelTest()
         {
             var rnd = new Random();

--- a/src/Tests/Unit/ServiceWireTests/TcpZkTests.cs
+++ b/src/Tests/Unit/ServiceWireTests/TcpZkTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using ServiceWire.TcpIp;
@@ -70,6 +69,21 @@ namespace ServiceWireTests
         }
 
         [Fact]
+        public async Task CalculateAsyncTest()
+        {
+	        var rnd = new Random();
+
+	        var a = rnd.Next(0, 100);
+	        var b = rnd.Next(0, 100);
+
+	        using (var clientProxy = new TcpClient<INetTester>(CreateZkClientEndPoint()))
+	        {
+		        var result = await clientProxy.Proxy.CalculateAsync(a, b);
+		        Assert.Equal(a + b, result);
+	        }
+        }
+
+		[Fact]
         public void SimpleParallelZkTest()
         {
             var rnd = new Random();


### PR DESCRIPTION
Added implementation to support using AsyncIO.
For example:
Common interface:
```cs
public interface ITest
{
	Task SetAsync(int a);
	Task<int> GetAsync();
}
```
Server side: 
```cs
public class Test : ITest
{
	public Task SetAsync(int a)
	{
		return Task.CompletedTask;
	}

	public Task<int> GetAsync()
	{
		return Task.FromResult(1);
	}
}
```
Client side:
```cs
using (var client = new TcpClient<ITest>(zkEndpoint))
{
	client.InjectLoggerStats(logger, stats);
	await client.Proxy.SetAsync(1);
	int value = await client.Proxy.GetAsync();
}
```

Also unit and integraton tests were added