### PR TITLE
extended supported framework range

### DIFF
--- a/src/ServiceWire/ProxyFactory.cs
+++ b/src/ServiceWire/ProxyFactory.cs
@@ -46,7 +46,7 @@ namespace ServiceWire
         {
             //create the type and construct an instance
             Type[] ctorArgTypes = new Type[] { typeof(Type), proxyBuilder.CtorType, typeof(ISerializer) };
-            Type t = proxyBuilder.TypeBuilder.CreateType();
+            Type t = proxyBuilder.TypeBuilder.CreateTypeInfo();
             var constructorInfo = t.GetConstructor(ctorArgTypes);
             if (constructorInfo != null)
             {
@@ -205,7 +205,7 @@ namespace ServiceWire
 
                 mIL.Emit(OpCodes.Dup);
                 mIL.Emit(OpCodes.Ldc_I4, i); //push the index onto the stack
-                mIL.Emit(OpCodes.Ldarg, i + 1); //load the i'th argument. This might be an address			
+                mIL.Emit(OpCodes.Ldarg, i + 1); //load the i'th argument. This might be an address
                 if (inputArgTypes[i].IsByRef)
                 {
                     if (inputType.IsValueType)

--- a/src/ServiceWire/ServiceWire.csproj
+++ b/src/ServiceWire/ServiceWire.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Tyler Jensen</Authors>
     <Company />
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Tests/Unit/ServiceWireTests/ServiceWireTests.csproj
+++ b/src/Tests/Unit/ServiceWireTests/ServiceWireTests.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp2.0;net462</TargetFrameworks>
-
+    <TargetFrameworks>netcoreapp3.1;netcoreapp3.0;netcoreapp2.2;netcoreapp2.1;netcoreapp2.0;net462;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
-
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
extended supported framework range by compiling ServiceWire as netstandard2.0 and 2.1
validated solution by adding additional targetframeworks to ServiceWireTests

@tylerje Additional context: We'd like to use this library for our project which can target both netcore and full framework. By compiling against netstandard, we can postpone the platform decision and base on the need of the user/other dependencies for a given project.