### PR TITLE
also fix Host._serializer being set twice (invalid value used to initialize ParameterTransferHelper)

### DIFF
--- a/src/ServiceWire/Host.cs
+++ b/src/ServiceWire/Host.cs
@@ -17,7 +17,7 @@ namespace ServiceWire
         protected int _compressionThreshold = 131072; //128KB
         protected ILog _log = new NullLogger();
         protected IStats _stats = new NullStats();
-        protected ISerializer _serializer;
+        protected readonly ISerializer _serializer;
         protected IZkRepository _zkRepository = new ZkNullRepository();
         private volatile bool _requireZk = false;
 
@@ -25,7 +25,7 @@ namespace ServiceWire
         protected ConcurrentDictionary<int, ServiceInstance> _services = new ConcurrentDictionary<int, ServiceInstance>();
         protected readonly ParameterTransferHelper _parameterTransferHelper;
 
-        public Host(ISerializer serializer = null)
+        public Host(ISerializer serializer)
         {
             _serializer = serializer ?? new DefaultSerializer();
             _parameterTransferHelper = new ParameterTransferHelper(_serializer);

--- a/src/ServiceWire/NamedPipes/NpHost.cs
+++ b/src/ServiceWire/NamedPipes/NpHost.cs
@@ -38,7 +38,6 @@ namespace ServiceWire.NamedPipes
         {
             base.Log = log;
             base.Stats = stats;
-            _serializer = serializer ?? new DefaultSerializer();
             _pipeName = pipeName;
             _listener = new NpListener(_pipeName, log: base.Log, stats: base.Stats);
             _listener.RequestReieved += ClientConnectionMade;

--- a/src/Tests/Unit/ServiceWireTests/NpTests.cs
+++ b/src/Tests/Unit/ServiceWireTests/NpTests.cs
@@ -180,6 +180,25 @@ namespace ServiceWireTests
             }
         }
 
+        [Fact]
+        public void ResponseWithOutParameterNewtonsoftSerializerTest()
+        {
+            using (var nphost = new NpHost(PipeName + "JsonResponseOut", serializer: new NewtonsoftSerializer()))
+            {
+                nphost.AddService<INetTester>(_tester);
+                nphost.Open();
+
+                using (var clientProxy = new NpClient<INetTester>(new NpEndPoint(PipeName + "JsonResponseOut"), new NewtonsoftSerializer()))
+                {
+                    int quantity = 0;
+                    var result = clientProxy.Proxy.Get(Guid.NewGuid(), "SomeLabel", 45.65, out quantity);
+                    Assert.Equal(44, quantity);
+                    Assert.NotEqual(default(TestResponse), result);
+                    Assert.Equal("MyLabel", result.Label);
+                }
+            }
+        }
+
         public void Dispose()
         {
             _nphost.Close();


### PR DESCRIPTION
I forgot to update the `Host` too in the previous PR...