### PR TITLE
Custom serializer fix

### DIFF
--- a/src/ServiceWire/Host.cs
+++ b/src/ServiceWire/Host.cs
@@ -25,8 +25,9 @@ namespace ServiceWire
         protected ConcurrentDictionary<int, ServiceInstance> _services = new ConcurrentDictionary<int, ServiceInstance>();
         protected readonly ParameterTransferHelper _parameterTransferHelper;
 
-        public Host()
+        public Host(ISerializer serializer = null)
         {
+            _serializer = serializer;
             _parameterTransferHelper = new ParameterTransferHelper(_serializer);
         }
 

--- a/src/ServiceWire/Host.cs
+++ b/src/ServiceWire/Host.cs
@@ -27,7 +27,7 @@ namespace ServiceWire
 
         public Host(ISerializer serializer = null)
         {
-            _serializer = serializer;
+            _serializer = serializer ?? new DefaultSerializer();
             _parameterTransferHelper = new ParameterTransferHelper(_serializer);
         }
 

--- a/src/ServiceWire/NamedPipes/NpHost.cs
+++ b/src/ServiceWire/NamedPipes/NpHost.cs
@@ -34,6 +34,7 @@ namespace ServiceWire.NamedPipes
         /// <param name="stats"></param>
         /// <param name="serializer">Inject your own serializer for complex objects and avoid using the Newtonsoft JSON DefaultSerializer.</param>
         public NpHost(string pipeName, ILog log = null, IStats stats = null, ISerializer serializer = null)
+            : base(serializer)
         {
             base.Log = log;
             base.Stats = stats;

--- a/src/ServiceWire/TcpIp/TcpHost.cs
+++ b/src/ServiceWire/TcpIp/TcpHost.cs
@@ -25,6 +25,7 @@ namespace ServiceWire.TcpIp
         /// <param name="serializer">Inject your own serializer for complex objects and avoid using the Newtonsoft JSON DefaultSerializer.</param>
         public TcpHost(int port, ILog log = null, IStats stats = null, 
             IZkRepository zkRepository = null, ISerializer serializer = null)
+            : base(serializer)
         {
             Initialize(new IPEndPoint(IPAddress.Any, port), log, stats, zkRepository, serializer);
         }

--- a/src/ServiceWire/TcpIp/TcpHost.cs
+++ b/src/ServiceWire/TcpIp/TcpHost.cs
@@ -27,7 +27,7 @@ namespace ServiceWire.TcpIp
             IZkRepository zkRepository = null, ISerializer serializer = null)
             : base(serializer)
         {
-            Initialize(new IPEndPoint(IPAddress.Any, port), log, stats, zkRepository, serializer);
+            Initialize(new IPEndPoint(IPAddress.Any, port), log, stats, zkRepository);
         }
 
         /// <summary>
@@ -43,16 +43,16 @@ namespace ServiceWire.TcpIp
         /// <param name="serializer">Inject your own serializer for complex objects and avoid using the Newtonsoft JSON DefaultSerializer.</param>
         public TcpHost(IPEndPoint endpoint, ILog log = null, IStats stats = null, 
             IZkRepository zkRepository = null, ISerializer serializer = null)
+            : base(serializer)
         {
-            Initialize(endpoint, log, stats, zkRepository, serializer);
+            Initialize(endpoint, log, stats, zkRepository);
         }
 
-        private void Initialize(IPEndPoint endpoint, ILog log, IStats stats, IZkRepository zkRepository, ISerializer serializer)
+        private void Initialize(IPEndPoint endpoint, ILog log, IStats stats, IZkRepository zkRepository)
         {
             base.Log = log;
             base.Stats = stats;
             base.ZkRepository = zkRepository ?? new ZkNullRepository();
-            _serializer = serializer ?? new DefaultSerializer();
             _endPoint = endpoint;
             _listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             _listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);


### PR DESCRIPTION
Great library! Noticed a little bug - NpHost(...) constructor calls parent Host() constructor without specifying the proper serializer, so the Host uses empty _serializer. It casuses ParameterTransferHelper's internal serializer to be default all the time. This is the fix