### PR TITLE
Fixing the Admin <-> NonAdmin communication

### DIFF
--- a/src/ServiceWire/NamedPipes/NpListener.cs
+++ b/src/ServiceWire/NamedPipes/NpListener.cs
@@ -13,9 +13,8 @@ namespace ServiceWire.NamedPipes
         private Thread runningThread;
         private EventWaitHandle terminateHandle = new EventWaitHandle(false, EventResetMode.AutoReset);
         private int _maxConnections = 254;
-#if NET462
         private PipeSecurity _pipeSecurity = null;
-#endif
+
         private ILog _log = new NullLogger();
         private IStats _stats = new NullStats();
 
@@ -29,13 +28,12 @@ namespace ServiceWire.NamedPipes
             if (maxConnections > 254) maxConnections = 254;
             _maxConnections = maxConnections;
             this.PipeName = pipeName;
-#if NET462
+
             _pipeSecurity = new PipeSecurity();
             SecurityIdentifier everyone = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
             _pipeSecurity.AddAccessRule(new PipeAccessRule(everyone, PipeAccessRights.ReadWrite, AccessControlType.Allow));
             _pipeSecurity.AddAccessRule(new PipeAccessRule(WindowsIdentity.GetCurrent().User, PipeAccessRights.FullControl, AccessControlType.Allow));
             _pipeSecurity.AddAccessRule(new PipeAccessRule(@"SYSTEM", PipeAccessRights.FullControl, AccessControlType.Allow));
-#endif
         }
 
         public void Start()
@@ -109,12 +107,9 @@ namespace ServiceWire.NamedPipes
         {
             try
             {
-#if NET462
-                var pipeStream = new NamedPipeServerStream(PipeName, PipeDirection.InOut, _maxConnections, 
+                var pipeStream = NamedPipeServerStreamConstructors.New(PipeName, PipeDirection.InOut, _maxConnections, 
                     PipeTransmissionMode.Byte, PipeOptions.None, 512, 512, _pipeSecurity);
-#else
-                var pipeStream = new NamedPipeServerStream(PipeName, PipeDirection.InOut, _maxConnections);
-#endif
+
                 pipeStream.WaitForConnection();
                 //Task.Factory.StartNew(() => ProcessClientThread(pipeStream), TaskCreationOptions.LongRunning);
                 Task.Factory.StartNew(() => ProcessClientThread(pipeStream));

--- a/src/ServiceWire/ServiceWire.csproj
+++ b/src/ServiceWire/ServiceWire.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NamedPipeServerStream.NetFrameworkVersion" Version="1.0.2" />
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />


### PR DESCRIPTION
It seems that PipeSecurity is not supported by .NET Core and it may be useful to access the admin process using pipe from non-admin process. I needed this functionality in my project and this approach seems working ok. Maybe it's a nice way to fix the issue while official pipe security support is not there yet.