### PR TITLE
Fix for AssemblyQualified names from userdefined types  in mscorlib g…

### DIFF
--- a/src/ServiceWire/NetExtensions.cs
+++ b/src/ServiceWire/NetExtensions.cs
@@ -15,11 +15,8 @@ namespace ServiceWire
         {
             // Do not qualify types from mscorlib/System.Private.CoreLib otherwise calling between process running with different frameworks won't work
             // i.e. "System.String, mscorlib" (.NET FW) != "System.String, System.Private.CoreLib" (.NET CORE)
-            if (t.Assembly.GetName().Name == "mscorlib" ||
-                t.Assembly.GetName().Name == "System.Private.CoreLib")
-                return t.FullName;
-
-            var name = t.AssemblyQualifiedName;
+            var name = ((t.Assembly.GetName().Name == "mscorlib" || t.Assembly.GetName().Name == "System.Private.CoreLib")) ? t.FullName : t.AssemblyQualifiedName;
+            // But since an mscorlib generic container can contain fully qualified types we always need to clean up the name
             name = Regex.Replace(name, @", Version=\d+.\d+.\d+.\d+", string.Empty);
             name = Regex.Replace(name, @", Culture=\w+", string.Empty);
             name = Regex.Replace(name, @", PublicKeyToken=\w+", string.Empty);


### PR DESCRIPTION
If you have use user defined type the routine NetExtensions.ToConfigName() correctly removes the versioning from it.
If you use a List<userdefinedtype> as a parameter of an interface the type will be listed as being from mscorlib and the same routine will not remove the versioning (which does appear in the FullName from the assembly).

The calls that use lists of userdefined types become version-sensitive. Any new build will not be able to communicate with older builds of software it wants to communicate with. The error will be that it cannot find the serverside equivalent of the call. Just for those methods and only if the versioning of the type differs.

The solution is to also use the RegExes in the routine on the fullname used for mscorlib/coreLib types. Tested and works in our test-environment (20+ apps communicating using servicewire)
