### PR TITLE
ICompressor implementation

### DIFF
--- a/src/ServiceWire/Aspects/InterceptChannel.cs
+++ b/src/ServiceWire/Aspects/InterceptChannel.cs
@@ -12,8 +12,8 @@ namespace ServiceWire.Aspects
 
         public InterceptPoint InterceptPoint { get { return _interceptPoint; } }
 
-        public InterceptChannel(Type interceptedType, InterceptPoint interceptPoint, ISerializer serializer)
-            : base(serializer)
+        public InterceptChannel(Type interceptedType, InterceptPoint interceptPoint, ISerializer serializer, ICompressor compressor)
+            : base(serializer, compressor)
         {
             _serviceType = interceptedType;
             _interceptPoint = interceptPoint;
@@ -73,7 +73,6 @@ namespace ServiceWire.Aspects
                 }
             }
 
-
             //Create a list of sync infos from the dictionary
             var syncSyncInfos = new List<MethodSyncInfo>();
             foreach (var kvp in _serviceInstance.InterfaceMethods)
@@ -120,11 +119,14 @@ namespace ServiceWire.Aspects
                         {
                             var matchingParameterTypes = true;
                             for (int i = 0; i < si.ParameterTypes.Length; i++)
+                            {
                                 if (!mdata[i + 1].Equals(si.ParameterTypes[i]))
                                 {
                                     matchingParameterTypes = false;
                                     break;
                                 }
+                            }
+
                             if (matchingParameterTypes)
                             {
                                 ident = si.MethodIdent;
@@ -139,11 +141,9 @@ namespace ServiceWire.Aspects
 
                 if (_serviceInstance.InterfaceMethods.ContainsKey(ident))
                 {
-                    MethodInfo method;
-                    _serviceInstance.InterfaceMethods.TryGetValue(ident, out method);
+                    _serviceInstance.InterfaceMethods.TryGetValue(ident, out var method);
 
-                    bool[] isByRef;
-                    _serviceInstance.MethodParametersByRef.TryGetValue(ident, out isByRef);
+                    _serviceInstance.MethodParametersByRef.TryGetValue(ident, out var isByRef);
 
                     returnType = (null == method) ? null : method.ReturnType;
 
@@ -179,8 +179,7 @@ namespace ServiceWire.Aspects
                         {
                             returnParameters = new object[] { exceptionOfConcern };
                             throw exceptionOfConcern;
-                        }
-                        else
+                        } else
                         {
                             returnParameters = new object[]
                             {

--- a/src/ServiceWire/Aspects/Interceptor.cs
+++ b/src/ServiceWire/Aspects/Interceptor.cs
@@ -4,25 +4,27 @@ namespace ServiceWire.Aspects
 {
     public static class Interceptor
     {
-        public static TTarget Intercept<TTarget>(TTarget target, CrossCuttingConcerns crossCuttingConcerns, ISerializer serializer = null) where TTarget : class
+        public static TTarget Intercept<TTarget>(TTarget target, CrossCuttingConcerns crossCuttingConcerns, ISerializer serializer = null, ICompressor compressor = null) where TTarget : class
         {
-            return Intercept<TTarget>(0, target, crossCuttingConcerns, serializer);
+            return Intercept<TTarget>(0, target, crossCuttingConcerns, serializer, compressor);
         }
 
-        public static TTarget Intercept<TTarget>(int id, TTarget target, CrossCuttingConcerns crossCuttingConcerns, ISerializer serializer = null) where TTarget : class
+        public static TTarget Intercept<TTarget>(int id, TTarget target, CrossCuttingConcerns crossCuttingConcerns, ISerializer serializer = null, ICompressor compressor = null) where TTarget : class
         {
             if (!typeof(TTarget).IsInterface) throw new ArgumentException("TTarget not an interface");
             if (null == target) throw new ArgumentNullException("target");
             if (null == serializer) serializer = new DefaultSerializer();
-            TTarget interceptedTarget = ProxyFactory.CreateProxy<TTarget>(typeof(InterceptChannel), 
-            typeof(InterceptPoint), 
-            new InterceptPoint 
-            { 
+            if (null == compressor) compressor = new DefaultCompressor();
+            TTarget interceptedTarget = ProxyFactory.CreateProxy<TTarget>(typeof(InterceptChannel),
+            typeof(InterceptPoint),
+            new InterceptPoint
+            {
                 Id = id,
                 Target = target,
-                Cut = crossCuttingConcerns 
+                Cut = crossCuttingConcerns
             },
-            serializer);
+            serializer,
+            compressor);
             return interceptedTarget;
         }
     }

--- a/src/ServiceWire/Channel.cs
+++ b/src/ServiceWire/Channel.cs
@@ -9,10 +9,12 @@ namespace ServiceWire
         protected ILog _logger = new NullLogger();
         protected IStats _stats = new NullStats();
         internal readonly ISerializer _serializer;
+        internal readonly ICompressor _compressor;
 
-        public Channel(ISerializer serializer)
+        public Channel(ISerializer serializer, ICompressor compressor)
         {
             _serializer = serializer ?? new DefaultSerializer();
+            _compressor = compressor ?? new DefaultCompressor();
         }
 
         public void InjectLoggerStats(ILog logger, IStats stats)
@@ -35,7 +37,7 @@ namespace ServiceWire
         /// names and -parameter types. This is used when invoking methods server side.
         /// When username and password supplied, zero knowledge encryption is used.
         /// </summary>
-        protected abstract void SyncInterface(Type serviceType, 
+        protected abstract void SyncInterface(Type serviceType,
             string username = null, string password = null);
 
         #region IDisposable Members

--- a/src/ServiceWire/DefaultCompressor.cs
+++ b/src/ServiceWire/DefaultCompressor.cs
@@ -1,0 +1,36 @@
+﻿using System.IO;
+using System.IO.Compression;
+
+namespace ServiceWire
+{
+    public class DefaultCompressor : ICompressor
+    {
+        public byte[] Compress(byte[] data)
+        {
+            using (var msCompressed = new MemoryStream())
+            {
+                using (var msObj = new MemoryStream(data))
+                {
+                    using (GZipStream gzs = new GZipStream(msCompressed, CompressionMode.Compress))
+                    {
+                        msObj.CopyTo(gzs);
+                    }
+                }
+                return msCompressed.ToArray();
+            }
+        }
+        public byte[] DeCompress(byte[] compressedBytes)
+        {
+            using (var msObj = new MemoryStream())
+            {
+                using (var msCompressed = new MemoryStream(compressedBytes))
+                using (var gzs = new GZipStream(msCompressed, CompressionMode.Decompress))
+                {
+                    gzs.CopyTo(msObj);
+                }
+                msObj.Seek(0, SeekOrigin.Begin);
+                return msObj.ToArray();
+            }
+        }
+    }
+}

--- a/src/ServiceWire/DefaultSerializer.cs
+++ b/src/ServiceWire/DefaultSerializer.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
-using System.Text;
 
 namespace ServiceWire
 {

--- a/src/ServiceWire/ICompressor.cs
+++ b/src/ServiceWire/ICompressor.cs
@@ -1,0 +1,8 @@
+﻿namespace ServiceWire
+{
+    public interface ICompressor
+    {
+        public byte[] Compress(byte[] data);
+        public byte[] DeCompress(byte[] compressedBytes);
+    }
+}

--- a/src/ServiceWire/ISerializer.cs
+++ b/src/ServiceWire/ISerializer.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ServiceWire
+﻿namespace ServiceWire
 {
     public interface ISerializer
     {

--- a/src/ServiceWire/NamedPipes/NpChannel.cs
+++ b/src/ServiceWire/NamedPipes/NpChannel.cs
@@ -14,8 +14,8 @@ namespace ServiceWire.NamedPipes
         /// <param name="serviceType"></param>
         /// <param name="npEndPoint"></param>
         /// <param name="serializer">Inject your own serializer for complex objects and avoid using the Newtonsoft JSON DefaultSerializer.</param>
-        public NpChannel(Type serviceType, NpEndPoint npEndPoint, ISerializer serializer)
-            : base(serializer)
+        public NpChannel(Type serviceType, NpEndPoint npEndPoint, ISerializer serializer, ICompressor compressor)
+            : base(serializer, compressor)
         {
             _serviceType = serviceType;
             _clientStream = new NamedPipeClientStream(npEndPoint.ServerName, npEndPoint.PipeName, PipeDirection.InOut);

--- a/src/ServiceWire/NamedPipes/NpClient.cs
+++ b/src/ServiceWire/NamedPipes/NpClient.cs
@@ -21,10 +21,12 @@ namespace ServiceWire.NamedPipes
         /// </summary>
         /// <param name="npAddress"></param>
         /// <param name="serializer">Inject your own serializer for complex objects and avoid using the Newtonsoft JSON DefaultSerializer.</param>
-        public NpClient(NpEndPoint npAddress, ISerializer serializer = null)
+        /// <param name="compressor">Inject your own compressor and avoid using the standard GZIP DefaultCompressor.</param>
+        public NpClient(NpEndPoint npAddress, ISerializer serializer = null, ICompressor compressor = null)
         {
             if (null == serializer) serializer = new DefaultSerializer();
-            _proxy = NpProxy.CreateProxy<TInterface>(npAddress, serializer);
+            if (null == compressor) compressor = new DefaultCompressor();
+            _proxy = NpProxy.CreateProxy<TInterface>(npAddress, serializer, compressor);
         }
 
         #region IDisposable Members

--- a/src/ServiceWire/NamedPipes/NpHost.cs
+++ b/src/ServiceWire/NamedPipes/NpHost.cs
@@ -33,8 +33,9 @@ namespace ServiceWire.NamedPipes
         /// <param name="log"></param>
         /// <param name="stats"></param>
         /// <param name="serializer">Inject your own serializer for complex objects and avoid using the Newtonsoft JSON DefaultSerializer.</param>
-        public NpHost(string pipeName, ILog log = null, IStats stats = null, ISerializer serializer = null)
-            : base(serializer)
+        /// <param name="compressor">Inject your own compressor and avoid using the standard GZIP DefaultCompressor.</param>
+        public NpHost(string pipeName, ILog log = null, IStats stats = null, ISerializer serializer = null, ICompressor compressor = null)
+            : base(serializer, compressor)
         {
             base.Log = log;
             base.Stats = stats;

--- a/src/ServiceWire/NamedPipes/NpProxy.cs
+++ b/src/ServiceWire/NamedPipes/NpProxy.cs
@@ -2,9 +2,9 @@ namespace ServiceWire.NamedPipes
 {
     public class NpProxy
     {
-        public static TInterface CreateProxy<TInterface>(NpEndPoint npAddress, ISerializer serializer) where TInterface : class
+        public static TInterface CreateProxy<TInterface>(NpEndPoint npAddress, ISerializer serializer, ICompressor compressor) where TInterface : class
         {
-            return ProxyFactory.CreateProxy<TInterface>(typeof(NpChannel), typeof(NpEndPoint), npAddress, serializer);
+            return ProxyFactory.CreateProxy<TInterface>(typeof(NpChannel), typeof(NpEndPoint), npAddress, serializer, compressor);
         }
     }
 }

--- a/src/ServiceWire/NetExtensions.cs
+++ b/src/ServiceWire/NetExtensions.cs
@@ -1,11 +1,5 @@
-﻿using System.Text.RegularExpressions;
-using System;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Collections.Generic;
+﻿using System;
+using System.Text.RegularExpressions;
 
 namespace ServiceWire
 {
@@ -58,35 +52,6 @@ namespace ServiceWire
         {
             var tm = new DefaultTypeMaker();
             return tm.GetDefault(t);
-        }
-
-        public static byte[] ToGZipBytes(this byte[] data)
-        {
-            using (var msCompressed = new MemoryStream())
-            {
-                using (var msObj = new MemoryStream(data))
-                {
-                    using (GZipStream gzs = new GZipStream(msCompressed, CompressionMode.Compress))
-                    {
-                        msObj.CopyTo(gzs);
-                    }
-                }
-                return msCompressed.ToArray();
-            }
-        }
-
-        public static byte[] FromGZipBytes(this byte[] compressedBytes)
-        {
-            using (var msObj = new MemoryStream())
-            {
-                using (var msCompressed = new MemoryStream(compressedBytes))
-                using (var gzs = new GZipStream(msCompressed, CompressionMode.Decompress))
-                {
-                    gzs.CopyTo(msObj);
-                }
-                msObj.Seek(0, SeekOrigin.Begin);
-                return msObj.ToArray();
-            }
         }
 
         public static string Flatten(this string src)

--- a/src/ServiceWire/TcpIp/TcpClient.cs
+++ b/src/ServiceWire/TcpIp/TcpClient.cs
@@ -5,30 +5,33 @@ namespace ServiceWire.TcpIp
 {
     public class TcpClient<TInterface> : IDisposable where TInterface : class
     {
-		public TInterface Proxy { get; }
+        public TInterface Proxy { get; }
 
-		public TcpClient(TcpEndPoint endpoint, ISerializer serializer = null)
+        public TcpClient(TcpEndPoint endpoint, ISerializer serializer = null, ICompressor compressor = null)
         {
             if (null == serializer) serializer = new DefaultSerializer();
-            Proxy = TcpProxy.CreateProxy<TInterface>(endpoint, serializer);
+            if (null == compressor) compressor = new DefaultCompressor();
+            Proxy = TcpProxy.CreateProxy<TInterface>(endpoint, serializer, compressor);
         }
 
-        public TcpClient(TcpZkEndPoint endpoint, ISerializer serializer = null)
+        public TcpClient(TcpZkEndPoint endpoint, ISerializer serializer = null, ICompressor compressor = null)
         {
             if (null == serializer) serializer = new DefaultSerializer();
-            Proxy = TcpProxy.CreateProxy<TInterface>(endpoint, serializer);
+            if (null == compressor) compressor = new DefaultCompressor();
+            Proxy = TcpProxy.CreateProxy<TInterface>(endpoint, serializer, compressor);
         }
 
-        public TcpClient(IPEndPoint endpoint, ISerializer serializer = null)
+        public TcpClient(IPEndPoint endpoint, ISerializer serializer = null, ICompressor compressor = null)
         {
             if (null == serializer) serializer = new DefaultSerializer();
-            Proxy = TcpProxy.CreateProxy<TInterface>(endpoint, serializer);
+            if (null == compressor) compressor = new DefaultCompressor();
+            Proxy = TcpProxy.CreateProxy<TInterface>(endpoint, serializer, compressor);
         }
 
         public void InjectLoggerStats(ILog logger, IStats stats)
         {
-	        var channel = Proxy as Channel;
-	        channel?.InjectLoggerStats(logger, stats);
+            var channel = Proxy as Channel;
+            channel?.InjectLoggerStats(logger, stats);
         }
 
         public bool IsConnected => (Proxy as TcpChannel)?.IsConnected == true;

--- a/src/ServiceWire/TcpIp/TcpHost.cs
+++ b/src/ServiceWire/TcpIp/TcpHost.cs
@@ -1,10 +1,10 @@
+using ServiceWire.ZeroKnowledge;
 using System;
-using System.Net.Sockets;
-using System.Net;
 using System.IO;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
-using ServiceWire.ZeroKnowledge;
 
 namespace ServiceWire.TcpIp
 {
@@ -23,9 +23,9 @@ namespace ServiceWire.TcpIp
         /// <param name="stats"></param>
         /// <param name="zkRepository">Only required to support zero knowledge authentication and encryption.</param>
         /// <param name="serializer">Inject your own serializer for complex objects and avoid using the Newtonsoft JSON DefaultSerializer.</param>
-        public TcpHost(int port, ILog log = null, IStats stats = null, 
-            IZkRepository zkRepository = null, ISerializer serializer = null)
-            : base(serializer)
+        public TcpHost(int port, ILog log = null, IStats stats = null,
+            IZkRepository zkRepository = null, ISerializer serializer = null, ICompressor compressor = null)
+            : base(serializer, compressor)
         {
             Initialize(new IPEndPoint(IPAddress.Any, port), log, stats, zkRepository);
         }
@@ -41,9 +41,10 @@ namespace ServiceWire.TcpIp
         /// <param name="stats"></param>
         /// <param name="zkRepository">Only required to support zero knowledge authentication and encryption.</param>
         /// <param name="serializer">Inject your own serializer for complex objects and avoid using the Newtonsoft JSON DefaultSerializer.</param>
-        public TcpHost(IPEndPoint endpoint, ILog log = null, IStats stats = null, 
-            IZkRepository zkRepository = null, ISerializer serializer = null)
-            : base(serializer)
+        /// <param name="compressor">Inject your own compressor and avoid using the standard GZIP DefaultCompressor.</param>
+        public TcpHost(IPEndPoint endpoint, ILog log = null, IStats stats = null,
+            IZkRepository zkRepository = null, ISerializer serializer = null, ICompressor compressor = null)
+            : base(serializer, compressor)
         {
             Initialize(endpoint, log, stats, zkRepository);
         }
@@ -182,7 +183,7 @@ namespace ServiceWire.TcpIp
             }
         }
 
-#region IDisposable Members
+        #region IDisposable Members
 
         private bool _disposed = false;
 
@@ -202,6 +203,6 @@ namespace ServiceWire.TcpIp
             base.Dispose(disposing);
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/ServiceWire/TcpIp/TcpProxy.cs
+++ b/src/ServiceWire/TcpIp/TcpProxy.cs
@@ -4,19 +4,19 @@ namespace ServiceWire.TcpIp
 {
     public sealed class TcpProxy
     {
-        public static TInterface CreateProxy<TInterface>(TcpZkEndPoint endpoint, ISerializer serializer) where TInterface : class
+        public static TInterface CreateProxy<TInterface>(TcpZkEndPoint endpoint, ISerializer serializer, ICompressor compressor) where TInterface : class
         {
-            return ProxyFactory.CreateProxy<TInterface>(typeof(TcpChannel), typeof(TcpZkEndPoint), endpoint, serializer);
+            return ProxyFactory.CreateProxy<TInterface>(typeof(TcpChannel), typeof(TcpZkEndPoint), endpoint, serializer, compressor);
         }
 
-        public static TInterface CreateProxy<TInterface>(TcpEndPoint endpoint, ISerializer serializer) where TInterface : class
+        public static TInterface CreateProxy<TInterface>(TcpEndPoint endpoint, ISerializer serializer, ICompressor compressor) where TInterface : class
         {
-            return ProxyFactory.CreateProxy<TInterface>(typeof(TcpChannel), typeof(TcpEndPoint), endpoint, serializer);
+            return ProxyFactory.CreateProxy<TInterface>(typeof(TcpChannel), typeof(TcpEndPoint), endpoint, serializer, compressor);
         }
 
-        public static TInterface CreateProxy<TInterface>(IPEndPoint endpoint, ISerializer serializer) where TInterface : class
+        public static TInterface CreateProxy<TInterface>(IPEndPoint endpoint, ISerializer serializer, ICompressor compressor) where TInterface : class
         {
-            return ProxyFactory.CreateProxy<TInterface>(typeof(TcpChannel), typeof(IPEndPoint), endpoint, serializer);
+            return ProxyFactory.CreateProxy<TInterface>(typeof(TcpChannel), typeof(IPEndPoint), endpoint, serializer, compressor);
         }
     }
 }

--- a/src/Tests/Unit/ServiceWireTests/ParameterTransferHelperTests.cs
+++ b/src/Tests/Unit/ServiceWireTests/ParameterTransferHelperTests.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using ServiceWire;
+using System;
 using System.IO;
-using ServiceWire;
 using Xunit;
 
 namespace ServiceWireTests
@@ -112,7 +112,7 @@ namespace ServiceWireTests
             var uis = new uint[] { 34578444, 45676456, 452456456, 452456456, 424556456 };
             TestArraySimpleType(uis);
 
-            var ls = new long[] { 34997766, 99887766, 34998866, 34987766, 34998877};
+            var ls = new long[] { 34997766, 99887766, 34998866, 34987766, 34998877 };
             TestArraySimpleType(ls);
 
             var uls = new ulong[] { 987675765654, 987758765654, 987758765654, 987675876654, 987675875654 };
@@ -170,7 +170,7 @@ namespace ServiceWireTests
 
         private object[] RunInAndOut(params object[] obj)
         {
-            var pth = new ParameterTransferHelper(new DefaultSerializer());
+            var pth = new ParameterTransferHelper(new DefaultSerializer(), new DefaultCompressor());
             object[] result = null;
             using (var ms = new MemoryStream())
             using (var writer = new BinaryWriter(ms))
@@ -184,7 +184,6 @@ namespace ServiceWireTests
         }
     }
 }
-
 
 /*
                 _parameterTypes.Add(typeof(bool), ParameterTypes.Bool);


### PR DESCRIPTION
Added an ICompressor interface along the lines of the ISerializer interface. Allows developers to swap in a different compression solution. The existing GZIP compression is used as DefaultCompressor. I plan to use ZStandard with dictionary compression in my own projects so thought this would be a nice way to add it as an optional feature to ServiceWire

All testcases still work on my machine using net6. Have not committed any project files so multitargeting should still work.