### PR TITLE
fix for sync serialization error

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 ServiceWire
 ===========
 
+### Capture serialization error bug fix in 5.4.1
+
+1. In .NET 5+, the BinaryFormatter is marked obsolete and prohibited in ASP.NET apps.
+2. This bug caused and end of stream error rather than capturing it properly. This version fixes that bug and exposes the limitation introduced in .NET 5+ on ASP.NET apps.
+3. Using ServiceWire in an ASP.NET app is still possible but requires the use of the [EnableUnsafeBinaryFormatterSerialization](https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/binaryformatter-serialization-obsolete) flag in your project file. Use this carefully and be sure you understand the risks. 
+
 ### ICompression added for injecting compression strategy in 5.4.0
 
 1. Added ICompression for injecting custom compression into usage.
@@ -133,3 +139,4 @@ Portions of this library are a derivative of [RemotingLite][].
   [NuGet package here]: http://www.nuget.org/packages/ServiceWire/
   [RemotingLite]: http://remotinglite.codeplex.com/
   [ServiceWire documentation]: https://github.com/tylerjensen/ServiceWire/wiki
+

--- a/src/ServiceWire/ServiceWire.csproj
+++ b/src/ServiceWire/ServiceWire.csproj
@@ -15,10 +15,10 @@
 		<PackageProjectUrl>https://github.com/tylerjensen/ServiceWire</PackageProjectUrl>
 		<PackageLicenseFile>License.txt</PackageLicenseFile>
 		<Copyright>Tyler Jensen 2013-2021</Copyright>
-		<Version>5.4.0</Version>
+		<Version>5.4.1</Version>
 		<Description>ServiceWire is a very fast and light weight service host and dynamic client library that simplifies the development and use of high performance remote procedure call (RPC) communication between .NET processes over Named Pipes or TCP/IP. And with the release of 2.0.0, ServiceWire now supports optional use of Zero Knowledge authentication with a fast variation of Secure Remote Password Protocol and strong Rijndael encryption of data across the wire via TCP without the need for public keys going across the wire.</Description>
 		<PackageTags>WCF Services Host Client NamedPipes TCP Messaging RPC Interception Zero Knowledge Secure Remote Password Protocol Serialization</PackageTags>
-		<PackageReleaseNotes>Adds ICompression added to allow compression strategy to be injected. Adds .NET 5.0 target.</PackageReleaseNotes>
+		<PackageReleaseNotes>Fixes interface sync serialization error capture.</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
An attempt to address issue #52 where stream error occurs due to an error in serializing ServiceSyncInfo not being handled and subsequent failure to send a 0 len response to indicate a sync error. 