### PR TITLE
Remove core library information from type name

### DIFF
--- a/src/ServiceWire/NetExtensions.cs
+++ b/src/ServiceWire/NetExtensions.cs
@@ -5,15 +5,24 @@ namespace ServiceWire
 {
     public static class NetExtensions
     {
+        private const string _netFwCoreLib = "mscorlib";
+        private const string _netCoreCoreLib = "System.Private.CoreLib";
+
         public static string ToConfigName(this Type t)
         {
             // Do not qualify types from mscorlib/System.Private.CoreLib otherwise calling between process running with different frameworks won't work
             // i.e. "System.String, mscorlib" (.NET FW) != "System.String, System.Private.CoreLib" (.NET CORE)
-            var name = ((t.Assembly.GetName().Name == "mscorlib" || t.Assembly.GetName().Name == "System.Private.CoreLib")) ? t.FullName : t.AssemblyQualifiedName;
+            var name = t.Assembly.GetName().Name == _netFwCoreLib || t.Assembly.GetName().Name == _netCoreCoreLib
+                ? t.FullName
+                : t.AssemblyQualifiedName;
+
             // But since an mscorlib generic container can contain fully qualified types we always need to clean up the name
             name = Regex.Replace(name, @", Version=\d+.\d+.\d+.\d+", string.Empty);
             name = Regex.Replace(name, @", Culture=\w+", string.Empty);
             name = Regex.Replace(name, @", PublicKeyToken=\w+", string.Empty);
+            name = name.Replace(", " + _netFwCoreLib, string.Empty);
+            name = name.Replace(", " + _netCoreCoreLib, string.Empty);
+
             return name;
         }
 


### PR DESCRIPTION
If you use a type which has generic type and use a core library type as that generic type (e.g. `List<int>`) then the core library module name is still present in the type name returned from `NetExtensions.ToConfigName()`.

This breaks .NET Framework <-> .NET Core compatibility as the type names will not match.

e.g.
On .NET Framework it will be ``System.Collections.Generic.List`1[[System.Int32, mscorlib]]``.
On .NET Core it will be ``System.Collections.Generic.List`1[[System.Int32, System.Private.CoreLib]]``.

I noticed https://github.com/tylerjensen/ServiceWire/pull/53 to remove the `Version`, `Culture` and `PublicKeyToken` from core library type names too which almost fixes this issue, however due to the extra `, mscorlib` and `, System.Private.CoreLib` parts it won't match the method signature or be able to create the type via `Type.GetType`.

By removing that part it is now able to send those types from .NET Framework to .NET Core and vice versa.