### PR TITLE
Cache ServiceSyncInfo by type and channel identifier

### DIFF
--- a/src/ServiceWire/IChannelIdentifier.cs
+++ b/src/ServiceWire/IChannelIdentifier.cs
@@ -1,0 +1,6 @@
+﻿namespace ServiceWire
+{
+    public interface IChannelIdentifier
+    {
+    }
+}

--- a/src/ServiceWire/NamedPipes/NpChannel.cs
+++ b/src/ServiceWire/NamedPipes/NpChannel.cs
@@ -7,6 +7,7 @@ namespace ServiceWire.NamedPipes
     public class NpChannel : StreamingChannel
     {
         private NamedPipeClientStream _clientStream;
+        private NpChannelIdentifier _channelIdentifier;
 
         /// <summary>
         /// Creates a connection to the concrete object handling method calls on the pipeName server side
@@ -18,6 +19,7 @@ namespace ServiceWire.NamedPipes
             : base(serializer, compressor)
         {
             _serviceType = serviceType;
+            _channelIdentifier = new NpChannelIdentifier(npEndPoint);
             _clientStream = new NamedPipeClientStream(npEndPoint.ServerName, npEndPoint.PipeName, PipeDirection.InOut);
             _clientStream.Connect(npEndPoint.ConnectTimeOutMs);
             _stream = new BufferedStream(_clientStream);
@@ -33,6 +35,8 @@ namespace ServiceWire.NamedPipes
                 throw;
             }
         }
+
+        protected override IChannelIdentifier ChannelIdentifier => _channelIdentifier;
 
         public override bool IsConnected { get { return (null != _clientStream) && _clientStream.IsConnected; } }
     }

--- a/src/ServiceWire/NamedPipes/NpChannelIdentifier.cs
+++ b/src/ServiceWire/NamedPipes/NpChannelIdentifier.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace ServiceWire.NamedPipes
+{
+    internal class NpChannelIdentifier : IChannelIdentifier, IEquatable<NpChannelIdentifier>
+    {
+        public string ServerName { get; }
+        public string PipeName { get; }
+
+        public NpChannelIdentifier(NpEndPoint npEndPoint)
+        {
+            ServerName = npEndPoint.ServerName;
+            PipeName = npEndPoint.PipeName;
+        }
+
+        public bool Equals(NpChannelIdentifier other)
+        {
+            return ServerName == other.ServerName
+                && PipeName == other.PipeName;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is NpChannelIdentifier other)
+            {
+                return Equals(other);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ServerName.GetHashCode() + PipeName.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/ServiceWire/ServiceSyncInfoCacheKey.cs
+++ b/src/ServiceWire/ServiceSyncInfoCacheKey.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace ServiceWire
+{
+    internal class ServiceSyncInfoCacheKey : IEquatable<ServiceSyncInfoCacheKey>
+    {
+        public Type Type { get; }
+        public IChannelIdentifier ChannelIdentifier { get; }
+
+        public ServiceSyncInfoCacheKey(Type type, IChannelIdentifier channelIdentifier)
+        {
+            Type = type;
+            ChannelIdentifier = channelIdentifier;
+        }
+
+        public bool Equals(ServiceSyncInfoCacheKey other)
+        {
+            return Type.Equals(other.Type)
+                && ChannelIdentifier.Equals(other.ChannelIdentifier);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ServiceSyncInfoCacheKey other)
+            {
+                return Equals(other);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return Type.GetHashCode() + ChannelIdentifier.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/ServiceWire/TcpIp/TcpChannel.cs
+++ b/src/ServiceWire/TcpIp/TcpChannel.cs
@@ -11,6 +11,7 @@ namespace ServiceWire.TcpIp
         private Socket _client;
         private string _username;
         private string _password;
+        private TcpChannelIdentifier _channelIdentifier;
 
         /// <summary>
         /// Creates a connection to the concrete object handling method calls on the server side
@@ -61,6 +62,7 @@ namespace ServiceWire.TcpIp
             _username = username;
             _password = password;
             _serviceType = serviceType;
+            _channelIdentifier = new TcpChannelIdentifier(endpoint);
             _client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp); // TcpClient(AddressFamily.InterNetwork);
             _client.LingerState.Enabled = false;
 
@@ -109,6 +111,8 @@ namespace ServiceWire.TcpIp
                 throw;
             }
         }
+
+        protected override IChannelIdentifier ChannelIdentifier => _channelIdentifier;
 
         public override bool IsConnected { get { return (null != _client) && _client.Connected; } }
 

--- a/src/ServiceWire/TcpIp/TcpChannelIdentifier.cs
+++ b/src/ServiceWire/TcpIp/TcpChannelIdentifier.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Net;
+
+namespace ServiceWire.TcpIp
+{
+    internal class TcpChannelIdentifier : IChannelIdentifier, IEquatable<TcpChannelIdentifier>
+    {
+        public string IpAddressAndPort { get; }
+
+        public TcpChannelIdentifier(IPEndPoint ipEndpoint)
+        {
+            IpAddressAndPort = ipEndpoint.ToString();
+        }
+
+        public bool Equals(TcpChannelIdentifier other)
+        {
+            return IpAddressAndPort == other.IpAddressAndPort;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is TcpChannelIdentifier other)
+            {
+                return Equals(other);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return IpAddressAndPort.GetHashCode();
+        }
+    }
+}


### PR DESCRIPTION
When calling a service on a host with the same interface that was called previously on a different host, the call will fail if the ServiceKeyIndex does not match up between them.

For example:

You have the interface `ISimpleInterface` defined in a shared library:
```
public interface ISimpleInterface
{
    void SimpleMethod();
}
```

Host 1 hosts a service which implements `ISimpleInterface`. When the service is added to the TcpHost, `ISimpleInterface` will have a `ServiceKeyIndex` of 0.
```
internal class Program
{
    static void Main(string[] args)
    {
        var tcpHost = new TcpHost(new IPEndPoint(IPAddress.Any, 28500));

        tcpHost.AddService<ISimpleInterface>(new SimpleClass());

        tcpHost.Open();

        Console.ReadKey();
    }
}

public class SimpleClass : ISimpleInterface
{
    public void SimpleMethod()
    {
        Console.WriteLine("Simple method 1 called");
    }
}
```

Host 2 also hosts a service which implements `ISimpleInterface`, however it also hosts another interface `ISomeOtherInterface` which is added prior to `ISimpleInterface`. Therefore `ISomeOtherInterface` will have a `ServiceKeyIndex` of 0 and `ISimpleInterface` will have a `ServiceKeyIndex` of 1.

```
internal class Program
{
    static void Main(string[] args)
    {
        var tcpHost = new TcpHost(new IPEndPoint(IPAddress.Any, 28501));

        tcpHost.AddService<ISomeOtherInterface>(new SomeOtherClass());
        tcpHost.AddService<ISimpleInterface>(new SimpleClass());

        tcpHost.Open();

        Console.ReadKey();
    }
}

public interface ISomeOtherInterface
{
    void SimpleMethod();
}

public class SomeOtherClass : ISomeOtherInterface
{
    public void SimpleMethod()
    {
        Console.WriteLine("Some other class called");
    }
}

public class SimpleClass : ISimpleInterface
{
    public void SimpleMethod()
    {
        Console.WriteLine("Simple method 2 called");
    }
}
```

The client then tries to connect to both hosts and makes a call to `ISimpleInterface`.

It first makes the call to host 2 which succeeds and caches `ISimpleInterface` inside of `SyncInfoCache` with a `ServiceKeyIndex` of 1.

It then attempts to make the call to host 1. While making it call it retrieves `ISimpleInterface` from the `SyncInfoCache`, however this is incorrect as the service on host 1 has a `ServiceKeyIndex` of 0 instead of 1. When it makes the call it will throw an `System.IO.EndOfStreamException: 'Unable to read beyond the end of the stream` exception due to this mismatch.

```
static void Main(string[] args)
{
    var tcpClient2 = new TcpClient<ISimpleInterface>(new IPEndPoint(IPAddress.Loopback, 28501));
    var tcpClient1 = new TcpClient<ISimpleInterface>(new IPEndPoint(IPAddress.Loopback, 28500));

    tcpClient2.Proxy.SimpleMethod();
    tcpClient1.Proxy.SimpleMethod();
}
```

Fix:
Include the client connection information into the key for `SyncInfoCache` so types are cached per connection rather than globally.