### PR TITLE
Fix NullReferenceException on dispose

### DIFF
--- a/src/ServiceWire/TcpIp/TcpHost.cs
+++ b/src/ServiceWire/TcpIp/TcpHost.cs
@@ -69,6 +69,9 @@ namespace ServiceWire.TcpIp
 
         protected override void StartListener()
         {
+            _listener.Bind(_endPoint);
+            _listener.Listen(8192);
+
             _acceptEventArg = new SocketAsyncEventArgs();
             _acceptEventArg.Completed += new EventHandler<SocketAsyncEventArgs>(acceptEventArg_Completed);
 
@@ -84,9 +87,6 @@ namespace ServiceWire.TcpIp
         {
             try
             {
-                _listener.Bind(_endPoint);
-                _listener.Listen(8192);
-
                 while (!_disposed)
                 {
                     // Set the event to nonsignaled state.

--- a/src/ServiceWire/TcpIp/TcpHost.cs
+++ b/src/ServiceWire/TcpIp/TcpHost.cs
@@ -69,6 +69,9 @@ namespace ServiceWire.TcpIp
 
         protected override void StartListener()
         {
+            _acceptEventArg = new SocketAsyncEventArgs();
+            _acceptEventArg.Completed += new EventHandler<SocketAsyncEventArgs>(acceptEventArg_Completed);
+
             Task.Factory.StartNew(Listen, TaskCreationOptions.LongRunning);
         }
 
@@ -83,9 +86,6 @@ namespace ServiceWire.TcpIp
             {
                 _listener.Bind(_endPoint);
                 _listener.Listen(8192);
-
-                _acceptEventArg = new SocketAsyncEventArgs();
-                _acceptEventArg.Completed += new EventHandler<SocketAsyncEventArgs>(acceptEventArg_Completed);
 
                 while (!_disposed)
                 {
@@ -192,7 +192,7 @@ namespace ServiceWire.TcpIp
                 if (disposing)
                 {
                     _listenResetEvent.Set();
-                    _acceptEventArg.Dispose();
+                    _acceptEventArg?.Dispose();
                     _listener.Close();
                     _listenResetEvent.Close();
                 }


### PR DESCRIPTION
If the TcpHost is closed too quickly after being opened (or closed without a preceding `Open()`), then a NullReferenceException is thrown:
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at ServiceWire.TcpIp.TcpHost.Dispose(Boolean disposing)
   at ServiceWire.Host.Dispose()
   at ServiceWire.Host.Close()
```

For example - closing it straight after opening:
```
var tcpHost = new TcpHost(new IPEndPoint(IPAddress.Any, 28502));

tcpHost.Open();

tcpHost.Close();
```

Or just calling `Close()` without calling `Open()` first:
```
var tcpHost = new TcpHost(new IPEndPoint(IPAddress.Any, 28502));

tcpHost.Close();
```

It looks like the NRE is on `_acceptEventArg` which is not set until the `Listen` task has started, so the fix is to start the listener and create `_acceptEventArg` before starting the `Listen` task. It also does a null check on `_acceptEventArg` on dispose to cater for closing the connection without a preceding `Open()`.