### PR TITLE
Add server-side stacktrace in exceptions

### DIFF
--- a/src/ServiceWire/StreamingChannel.cs
+++ b/src/ServiceWire/StreamingChannel.cs
@@ -255,7 +255,10 @@ namespace ServiceWire
                 }
 
                 if (messageType == MessageType.ThrowException)
-                    throw (Exception)outParams[0];
+                {
+                    var originalException = (Exception)outParams[0];
+                    throw new Exception(originalException.Message, originalException);
+                }
 
                 MethodSyncInfo methodSyncInfo = _syncInfo.MethodInfos[ident];
                 var returnType = methodSyncInfo.MethodReturnType.ToType();

--- a/src/ServiceWire/StreamingChannel.cs
+++ b/src/ServiceWire/StreamingChannel.cs
@@ -257,7 +257,7 @@ namespace ServiceWire
                 if (messageType == MessageType.ThrowException)
                 {
                     var originalException = (Exception)outParams[0];
-                    throw new Exception(originalException.Message, originalException);
+                    throw new Exception($"{originalException.GetType().FullName}: {originalException.Message}, originalException);
                 }
 
                 MethodSyncInfo methodSyncInfo = _syncInfo.MethodInfos[ident];

--- a/src/ServiceWire/StreamingChannel.cs
+++ b/src/ServiceWire/StreamingChannel.cs
@@ -257,7 +257,7 @@ namespace ServiceWire
                 if (messageType == MessageType.ThrowException)
                 {
                     var originalException = (Exception)outParams[0];
-                    throw new Exception($"{originalException.GetType().FullName}: {originalException.Message}, originalException);
+                    throw new Exception($"{originalException.GetType().FullName}: {originalException.Message}", originalException);
                 }
 
                 MethodSyncInfo methodSyncInfo = _syncInfo.MethodInfos[ident];


### PR DESCRIPTION
Give details of what happened on the server-side as part of the inner-exception. Otherwise, only the exception message is displayed, and the stack trace is from the client code: 

```txt
   at ServiceWire.StreamingChannel.InvokeMethod(String metaData, Object[] parameters)
   <client call stack>
```

When investigating issues, only having only the message is not much helpful.