### PR TITLE
Introduce NamedPipeServerStreamFactory

### DIFF
--- a/src/ServiceWire/NamedPipes/DefaultNamedPipeServerStreamFactory.cs
+++ b/src/ServiceWire/NamedPipes/DefaultNamedPipeServerStreamFactory.cs
@@ -1,0 +1,12 @@
+﻿using System.IO.Pipes;
+
+namespace ServiceWire.NamedPipes
+{
+    public class DefaultNamedPipeServerStreamFactory : INamedPipeServerStreamFactory
+    {
+        public NamedPipeServerStream Create(string pipeName, PipeDirection direction, int maxNumberOfServerInstances, PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize)
+        {
+            return new NamedPipeServerStream(pipeName, direction, maxNumberOfServerInstances, transmissionMode, options, inBufferSize, outBufferSize);
+        }
+    }
+}

--- a/src/ServiceWire/NamedPipes/INamedPipeServerStreamFactory.cs
+++ b/src/ServiceWire/NamedPipes/INamedPipeServerStreamFactory.cs
@@ -1,0 +1,9 @@
+﻿using System.IO.Pipes;
+
+namespace ServiceWire.NamedPipes
+{
+    public interface INamedPipeServerStreamFactory
+    {
+        NamedPipeServerStream Create(string pipeName, PipeDirection direction, int maxNumberOfServerInstances, PipeTransmissionMode transmissionMode, PipeOptions options, int inBufferSize, int outBufferSize);
+    }
+}

--- a/src/ServiceWire/NamedPipes/NpHost.cs
+++ b/src/ServiceWire/NamedPipes/NpHost.cs
@@ -34,13 +34,14 @@ namespace ServiceWire.NamedPipes
         /// <param name="stats"></param>
         /// <param name="serializer">Inject your own serializer for complex objects and avoid using the Newtonsoft JSON DefaultSerializer.</param>
         /// <param name="compressor">Inject your own compressor and avoid using the standard GZIP DefaultCompressor.</param>
-        public NpHost(string pipeName, ILog log = null, IStats stats = null, ISerializer serializer = null, ICompressor compressor = null)
+        /// <param name="streamFactory">Inject your own factory for creating the named pipe server. Can be used with NamedPipeServerStreamAcl to set the ACL on Windows platforms.</param>
+        public NpHost(string pipeName, ILog log = null, IStats stats = null, ISerializer serializer = null, ICompressor compressor = null, INamedPipeServerStreamFactory streamFactory = null)
             : base(serializer, compressor)
         {
             base.Log = log;
             base.Stats = stats;
             _pipeName = pipeName;
-            _listener = new NpListener(_pipeName, log: base.Log, stats: base.Stats);
+            _listener = new NpListener(_pipeName, log: base.Log, stats: base.Stats, streamFactory: streamFactory);
             _listener.RequestReieved += ClientConnectionMade;
         }
 

--- a/src/ServiceWire/NamedPipes/NpListener.cs
+++ b/src/ServiceWire/NamedPipes/NpListener.cs
@@ -12,7 +12,7 @@ namespace ServiceWire.NamedPipes
         private int _maxConnections = 254;
         private ILog _log = new NullLogger();
         private IStats _stats = new NullStats();
-        private INamedPipeServerStreamFactory _streamFactory = new DefaultNamedPipeServerStreamFactory();
+        private INamedPipeServerStreamFactory _streamFactory;
 
         public string PipeName { get; set; }
         public event EventHandler<PipeClientConnectionEventArgs> RequestReieved;
@@ -24,7 +24,7 @@ namespace ServiceWire.NamedPipes
             if (maxConnections > 254) maxConnections = 254;
             _maxConnections = maxConnections;
             this.PipeName = pipeName;
-            _streamFactory= streamFactory ?? _streamFactory;
+            _streamFactory = streamFactory ?? new DefaultNamedPipeServerStreamFactory();
         }
 
         public void Start()


### PR DESCRIPTION
Allows callers to use NamedPipeServerStreamAcl without introducing additional dependencies to ServiceWire.