### PR TITLE
Ensure synchronous handling does not block new requests and allow clearing SyncInfoCache

### DIFF
--- a/src/ServiceWire/StreamingChannel.cs
+++ b/src/ServiceWire/StreamingChannel.cs
@@ -28,6 +28,11 @@ namespace ServiceWire
             _parameterTransferHelper = new ParameterTransferHelper(_serializer, _compressor);
         }
 
+        public static void ClearCachedSyncInfo()
+        {
+            SyncInfoCache.Clear();
+        }
+
         protected virtual IChannelIdentifier ChannelIdentifier { get; }
 
         /// <summary>


### PR DESCRIPTION
There are two changes here:

1. Fix issue https://github.com/tylerjensen/ServiceWire/issues/46 where accepting TCP clients synchronously is blocking new clients from being accepted until the terminating request is received on the synchronous client.
    * I don't know of a reliable way to get [AcceptAsync](https://learn.microsoft.com/en-us/dotnet/api/system.net.sockets.socket.acceptasync#system-net-sockets-socket-acceptasync(system-net-sockets-socketasynceventargs)) to return `false`, however it has happened in a production application a couple times and I am able to replicate it in a test application by continuously creating `TcpClient`s until one connection is eventually handled synchronously by the host (and blocks all future connections).

2. Allow the `SyncInfoCache` cache to be cleared.
    * We have a scenario in our application where the client needs to reconnect to the host after it updates, however the host may have changed services as part of the update. This causes the client's cached sync info to be out of date which may break some remote calls, so we need to clear it out and re-sync interfaces with the host. Currently we are using reflection to clear out this cache, so it would be nice to have a proper way to do this.