### PR TITLE
Fix for .NET10 - channelType does not inherit from Channel

### DIFF
--- a/src/ServiceWire/ProxyFactory.cs
+++ b/src/ServiceWire/ProxyFactory.cs
@@ -18,7 +18,7 @@ namespace ServiceWire
 
         public static TInterface CreateProxy<TInterface>(Type channelType, Type ctorArgType, object channelCtorValue, ISerializer serializer, ICompressor compressor, ILog logger, IStats stats) where TInterface : class
         {
-            if (!channelType.InheritsFrom(typeof(Channel))) throw new ArgumentException("channelType does not inherit from Channel");
+            if (!typeof(Channel).IsAssignableFrom(channelType)) throw new ArgumentException("channelType does not inherit from Channel");
             Type interfaceType = typeof(TInterface);
 
             //derive unique key for this dynamic assembly by interface, channel and ctor type names


### PR DESCRIPTION
The Error 'channelType does not inherit from Channel' comes from an inheritance check issue that apparently changed a bit with .NET10 
Replacing InheritsFrom with IsAssignableFrom fixed it for us.
